### PR TITLE
ES6 implementation for Redis adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coffee-script": "git://github.com/alubbe/coffee-script.git#efca28"
   },
   "scripts": {
-    "prepublish": "coffee -v --nodejs --harmony -o lib/ -c src/*.coffee"
+    "prepublish": "coffee --nodejs --harmony -o lib/ -c src/*.coffee"
   },
   "repository": {
     "type": "git",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,4 +2,4 @@ module.exports =
   # Mongo: require "./mongo-adapter"
   Memory: require "./memory-adapter"
   # ElasticSearch: require "./elasticsearch-adapter"
-  # Redis: require "./redis-adapter"
+  Redis: require "./redis-adapter"

--- a/test/interface.coffee
+++ b/test/interface.coffee
@@ -52,5 +52,7 @@ module.exports = async (adapter) ->
       yield books.delete key
       assert.equal (yield books.get key), null
 
+    yield adapter.close()
+
   catch error
     console.log error

--- a/test/redis.coffee
+++ b/test/redis.coffee
@@ -1,13 +1,7 @@
-Suite = require "./interface"
+tests = require "./interface"
 {Redis} = require "../src/index"
-{EventChannel} = require "mutual"
 
-events = new EventChannel
-
-adapter = new Redis.Adapter
-  events: events
+tests new Redis.Adapter
   port: 6379
   host: "127.0.0.1"
 
-Suite.run "Redis Adapter", adapter, ->
-  adapter.close()


### PR DESCRIPTION
## Summary

This adds a ES6 implementation for the Redis adapter. Test cases included (and passing).

Also fixes a bug in the `prepublish` script.

## Note

I'm not so happy with having the `adapter.client` field be a promise, as it creates the necessity for some awkwardness (on lines 46 and 51 of `src/redis-adapter.coffee`). Not sure if there's a better way to handle a collaborator which requires a promise to initialize. 