### PR TITLE
ES6 Memory Adapter: .all() on new collection returns non-empty array

### DIFF
--- a/src/memory-adapter.coffee
+++ b/src/memory-adapter.coffee
@@ -38,7 +38,7 @@ class Collection extends BaseCollection
     delete @collection[key]
     w old
 
-  all: -> @find (Object.keys @collection)
+  all: -> @find.apply @, (Object.keys @collection)
 
   count: -> w (Object.keys @collection).length
 

--- a/test/interface.coffee
+++ b/test/interface.coffee
@@ -30,6 +30,9 @@ module.exports = async (adapter) ->
       books = yield adapter.collection "books"
       assert.equal books.put?, true
 
+    yield test "New collection is empty", async ->
+      assert.equal (yield books.all()).length, 0
+
     yield test "Put an object into a collection", async ->
       yield books.put key, book
 


### PR DESCRIPTION
This fixes #21.

