### PR TITLE
Fixing #23, Memory adapter returns a reference rather than a clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "elasticsearchclient": "0.5.x",
-    "fairmont": "0.4.x",
+    "fairmont": "1.0.0-alpha-09",
     "mongodb": "1.2.x",
     "mutual": "0.4.x",
     "redis": "~0.10.1",

--- a/src/memory-adapter.coffee
+++ b/src/memory-adapter.coffee
@@ -1,5 +1,5 @@
 w = require "when"
-{type} = require "fairmont"
+{clone} = require "fairmont"
 {BaseAdapter,BaseCollection} = require ("./base-adapter")
 
 class Adapter extends BaseAdapter
@@ -29,7 +29,8 @@ class Collection extends BaseCollection
 
   find: (keys...) -> w.all ((@get key) for key in keys)
 
-  get: (key) -> w @collection[key]
+  get: (key) ->
+    w clone @collection[key]
 
   put: (key,object) -> w @collection[key] = object
 

--- a/src/redis-adapter.coffee
+++ b/src/redis-adapter.coffee
@@ -1,7 +1,7 @@
 w = require "when"
 async = (require "when/generator").lift
 {liftAll} = require "when/node"
-{type,merge} = require "fairmont"
+{merge} = require "fairmont"
 redis = require "redis"
 {BaseAdapter,BaseCollection} = require ("./base-adapter")
 

--- a/test/interface.coffee
+++ b/test/interface.coffee
@@ -40,6 +40,11 @@ module.exports = async (adapter) ->
       _book = yield books.get key
       assert.deepEqual book, _book
 
+    yield test "Uncommitted changes are not stored", async ->
+      _book = yield books.get key
+      _book.published = "2069"
+      assert.equal (yield books.get key).published, "1969"
+
     yield test "Find an object in a collection", async ->
       [_book] = yield books.find key
       assert.deepEqual _book, book


### PR DESCRIPTION
This fixes #23.

### NOTE

This currently fails due to https://github.com/pandastrike/fairmont/issues/26