### PR TITLE
Fixing two bugs with Adapter#collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "when": "^3.4.6"
   },
   "devDependencies": {
+    "amen": "^1.0.0-alpha-06",
     "coffee-script": "git://github.com/alubbe/coffee-script.git#efca28"
   },
   "scripts": {
-    "prepublish": "coffee --nodejs --harmony -o lib/ -c src/*.coffee"
+    "prepublish": "coffee --nodejs --harmony -o lib/ -c src/*.coffee",
+    "test": "coffee --nodejs --harmony test/index.coffee"
   },
   "repository": {
     "type": "git",

--- a/src/memory-adapter.coffee
+++ b/src/memory-adapter.coffee
@@ -14,7 +14,7 @@ class Adapter extends BaseAdapter
   connect: -> w @
 
   collection: (name) ->
-    w @database[name] = Collection.make
+    w @database[name] ?= Collection.make
       collection: {}
       adapter: @
       logger: @logger

--- a/src/redis-adapter.coffee
+++ b/src/redis-adapter.coffee
@@ -40,7 +40,7 @@ class Adapter extends BaseAdapter
           reject err
 
   collection: (name) ->
-    Collection.make
+    w Collection.make
       name: name
       adapter: @
 

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,10 +1,4 @@
-{extname} = require "path"
-{readdir} = require "fairmont"
-
-allow = (file) -> extname(file) == ".coffee" and (file != "index.coffee")
-
-# TODO: for this to work, we'd need to start the associated database
-# first, before running the tests
-
-for file in readdir(__dirname) when allow file
-  require "./#{file}"
+require "./memory"
+require "./redis"
+# require "./elasticsearch"
+# require "./mongo"

--- a/test/interface.coffee
+++ b/test/interface.coffee
@@ -40,6 +40,13 @@ module.exports = async (adapter) ->
       _book = yield books.get key
       assert.deepEqual book, _book
 
+    yield test "Count objects in collection", async ->
+      assert.equal 1, yield books.count()
+
+    yield test "Calling collection again returns same collection", async ->
+      _books = yield adapter.collection "books"
+      assert.equal 1, yield _books.count()
+
     yield test "Uncommitted changes are not stored", async ->
       _book = yield books.get key
       _book.published = "2069"


### PR DESCRIPTION
## Summary

It's a 2fer!

This fixes #26: Memory adapter: `collection` overwrites existing collections
And #27: Redis adapter's `collection` method does not return a promise

## Tests

Added a test case for #26. Also (finally), tests can now be run via `npm test`.