### PR TITLE
Adding the More Options to Client Creation Method

### DIFF
--- a/src/redis-adapter.coffee
+++ b/src/redis-adapter.coffee
@@ -66,10 +66,22 @@ class Collection extends BaseCollection
 
   get: async (key) ->
     res = yield @adapter.client.hget @name, key
-    if res? then JSON.parse(res) else null
+    if res?
+      # If we're pulling a buffer, no need to parse.
+      if @adapter.options.return_buffers
+        return res
+      else
+        return JSON.parse(res)
+    else
+      return null
+
 
   put: (key,object) ->
-    @adapter.client.hset @name, key, JSON.stringify(object)
+    if @adapter.options.return_buffers
+      # If we're storing a buffer, don't stringify.
+      @adapter.client.hset @name, key, object
+    else
+      @adapter.client.hset @name, key, JSON.stringify(object)
 
   delete: (key) ->
     @adapter.client.hdel @name, key

--- a/src/redis-adapter.coffee
+++ b/src/redis-adapter.coffee
@@ -1,7 +1,7 @@
 w = require "when"
 async = (require "when/generator").lift
 {liftAll} = require "when/node"
-{type,merge} = require "fairmont"
+{type, merge} = require "fairmont"
 redis = require "redis"
 {BaseAdapter,BaseCollection} = require ("./base-adapter")
 
@@ -27,10 +27,15 @@ class Adapter extends BaseAdapter
     super(@configuration)
     @log ?= console.log
 
+    @options = {}
+    @options[k] = v for k, v of @configuration when k != "port" && k != "host"
+
   connect: ->
     w.promise (resolve, reject) =>
       # create client
-      client = redis.createClient(@configuration.port, @configuration.host)
+      extra = @configuration
+      delete extra,
+      client = redis.createClient(@configuration.port, @configuration.host, @options)
         .on "ready", =>
           @log "RedisAdapter: Connected to Redis server @ #{@configuration.host}:#{@configuration.port}"
           @client = liftAll(redis.RedisClient.prototype, liftCommands, client)

--- a/src/redis-adapter.coffee
+++ b/src/redis-adapter.coffee
@@ -33,8 +33,6 @@ class Adapter extends BaseAdapter
   connect: ->
     w.promise (resolve, reject) =>
       # create client
-      extra = @configuration
-      delete extra,
       client = redis.createClient(@configuration.port, @configuration.host, @options)
         .on "ready", =>
           @log "RedisAdapter: Connected to Redis server @ #{@configuration.host}:#{@configuration.port}"


### PR DESCRIPTION
For Redis, Pirate uses the `redis` library to generate a client.  Previously, only the `host` and `port` could be set, but there are additional options.  The `redis` library also supports storing and returning buffers, and I needed that for a project.

@dyoder, I've added some code to allow additional options, but we should probably talk about which options we'd like to support because they may require additional changes.  For example, with buffers, Pirate must avoid stringifying them. 

Also, I'd like you to publish this once it's merged.  I have a monkey-patch working for Shopperr, but it would be nice to have this in the npm version, please.